### PR TITLE
(fix) nginx: [warn] the "listen ... http2" directive is deprecated

### DIFF
--- a/app/templates/nginx/load_balancer.conf
+++ b/app/templates/nginx/load_balancer.conf
@@ -7,7 +7,8 @@ upstream {{ site_name }}_backend {
 {% if ssl_enabled %}
 # HTTPS server block
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name {{ domain }};
     
     # SSL Certificate configuration

--- a/app/templates/nginx/proxy.conf
+++ b/app/templates/nginx/proxy.conf
@@ -1,7 +1,8 @@
 {% if ssl_enabled %}
 # HTTPS server block
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name {{ domain }};
     
     # SSL Certificate configuration

--- a/app/templates/nginx/static.conf
+++ b/app/templates/nginx/static.conf
@@ -1,7 +1,8 @@
 {% if ssl_enabled %}
 # HTTPS server block
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name {{ domain }};
     
     # SSL Certificate configuration

--- a/docs/security.md
+++ b/docs/security.md
@@ -214,7 +214,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
+    listen 443 ssl;
+    http2 on;
     server_name your-domain.com;
     
     # SSL configuration


### PR DESCRIPTION
fixes the warning: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead